### PR TITLE
added line about log into eNotices2 web

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -21,10 +21,12 @@ User authentication and authorisation (for those TED APIs that require it) is co
 
 You can generate and manage your own API keys by logging-in to your account in the link:https://developer.ted.europa.eu[**TED Developer Portal**]footnote:portal[{dev-portal}].
 
+If you use the the eNotices2 API, after you generate your key, please log into the link:https://enotices2.ted.europa.eu[eNotices2 website] at least once to pair your account.
+
 NOTE: Only one API key is allowed per user. The creation of a new API key implies the automatic revocation of the previous one.
 
 
-=== API key Generation
+=== API key generation
 
 You can generate an API Key by logging into the TED Developer Portalfootnote:portal[] and clicking on the "Manage your API Keys" button. To login to the TED Developer Portal you will need a valid EU Loginfootnote:eu-login[{eu-login}] account. 
 


### PR DESCRIPTION
Need to say about logging into eNotices2 web to be able to pair account with eNotices2 API submissions.