### PR TITLE
Add Search API hierarchy note (CPV/NUTS) to Getting started

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -98,8 +98,7 @@ NOTE: The Search API does not require a key.
 *  Do not test in the Production environment, as it is reserved for notices that will be published on TED.
 *  For more information, see section <<Testing your apps>>.
 
-[NOTE.note-green]
-When querying the Search API, please note that business sectors and geographical locations are structured hierarchically. To optimize your data parsing, consult our pages on https://ted.europa.eu/en/simap/cpv[CPV^] and https://ted.europa.eu/en/simap/nuts[NUTS^].
+NOTE: When querying the Search API, please note that business sectors and place of performance are structured hierarchically. To optimize your data parsing, consult our pages on https://ted.europa.eu/en/simap/cpv[CPV^] and https://ted.europa.eu/en/simap/nuts[NUTS^].
 
 
 IMPORTANT: eSenders and developers can create multiple accounts in the Preview environment for testing. In the Production environment, only one account and one API key per EU Login are allowed. We strongly recommend using a shared or functional email address for setting up Production accounts instead of a personal email.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -92,13 +92,15 @@ NOTE: Copy and save your API key upon creation; it cannot be retrieved later.
 
 NOTE: The Search API does not require a key.
 
-TIP: When querying the Search API, please note that business sectors and geographical locations are structured hierarchically. To optimize your data parsing, consult our pages on *CPV* and *NUTS*.
-
 [start=3]
 . *Test* in the https://docs.ted.europa.eu/eforms-common/preview/index.html[eForms *Preview* Environment]
 
 *  Do not test in the Production environment, as it is reserved for notices that will be published on TED.
 *  For more information, see section <<Testing your apps>>.
+
+[NOTE.note-green]
+When querying the Search API, please note that business sectors and geographical locations are structured hierarchically. To optimize your data parsing, consult our pages on https://ted.europa.eu/en/simap/cpv[CPV^] and https://ted.europa.eu/en/simap/nuts[NUTS^].
+
 
 IMPORTANT: eSenders and developers can create multiple accounts in the Preview environment for testing. In the Production environment, only one account and one API key per EU Login are allowed. We strongly recommend using a shared or functional email address for setting up Production accounts instead of a personal email.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -92,6 +92,8 @@ NOTE: Copy and save your API key upon creation; it cannot be retrieved later.
 
 NOTE: The Search API does not require a key.
 
+TIP: When querying the Search API, please note that business sectors and geographical locations are structured hierarchically. To optimize your data parsing, consult our pages on *CPV* and *NUTS*.
+
 [start=3]
 . *Test* in the https://docs.ted.europa.eu/eforms-common/preview/index.html[eForms *Preview* Environment]
 


### PR DESCRIPTION
Adds a NOTE to the Getting started section explaining that business sectors and place of performance are hierarchical, with links to the CPV and NUTS pages. Wording aligned with eForms terminology. Tested locally and in acceptance.